### PR TITLE
update instructions to match current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ Designed for the ATmega328p.
 # Usage
 
 ```bash
-xargo build --target avr-atmega328p --release
+rustup run avr-toolchain xargo build --target avr-atmega328p --release
 
-# there is now an ELF file at target/atmega328p/debug/blink.elf
+# there is now an ELF file at target/atmega328p/release/blink.elf
 ```
 
+You may need to invoke the build like this instead, as the current
+version of `avr-rust` is based on the dev channel:
+
+```
+XARGO_RUST_SRC=/path/to/avr-rust rustup run avr-toolchain xargo build --target avr-atmega328p --release --verbose
+```


### PR DESCRIPTION
* Fix path to the `.elf` file
* Show how to build without changing the default toolchain