### PR TITLE
Prevent LLVM from optimizing away busy loop

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
-#![feature(lang_items, unwind_attributes)]
-#![feature(asm)]
+#![feature(asm, lang_items, unwind_attributes)]
 
 #![no_std]
 #![no_main]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(lang_items, unwind_attributes)]
+#![feature(asm)]
 
 #![no_std]
 #![no_main]
@@ -28,7 +29,9 @@ pub extern fn main() {
 
 /// A small busy loop.
 fn small_delay() {
-    for _ in 0..10000 { }
+    for _ in 0..400000 {
+        unsafe { asm!("" :::: "volatile")}
+    }
 }
 
 // These do not need to be in a module, but we group them here for clarity.


### PR DESCRIPTION
Idea is from https://github.com/rust-lang/rust/issues/28728.
Also, increase the loop to 400000 cycles so the blink is visible.