### PR TITLE
[target spec] Remove unnecessary linking parameters

### DIFF
--- a/avr-atmega328p.json
+++ b/avr-atmega328p.json
@@ -14,16 +14,10 @@
   "exe-suffix": ".elf",
   "eh-frame-header": false,
   "pre-link-args": {
-    "gcc": [
-      "-Os",
-      "-mmcu=atmega328p"
-    ]
+    "gcc": ["-mmcu=atmega328p"]
   },
   "late-link-args": {
-    "gcc": [
-      "-lc",
-      "-lgcc"
-    ]
+    "gcc": ["-lgcc"]
   },
   "target-c-int-width": "16",
   "target-endian": "little",


### PR DESCRIPTION
Libc is not required. Also, '-Os' is a NOP when passed to the linker.