### PR TITLE
Temporary LLVM Error Workaround

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,5 @@
+# TODO: Remove this file once issue #29 is resolved upstream
+# Upstream: https://github.com/rust-lang/compiler-builtins/issues/400
+[toolchain]
+channel    = "nightly-2021-01-07"
+components = ["rust-src"]


### PR DESCRIPTION
This patch will make users of rustup transparently build using the last known working version of Rust for this project instead of having it fail to compile and leaving the user to figure out what went wrong.

See #29 for info on error.