### PR TITLE
Enable LTO for release builds to fix blink example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ edition = '2018'
 
 [dependencies]
 ruduino = "0.3"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
The LED blinks much too rapidly without LTO enabled.
With LTO enabled, the LED blinks 1 second on, 1 second off.

Fixes #34.