### PR TITLE
Remove unused&deprecated llvm_asm feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(llvm_asm)]
-
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
#38 is closed, but blink is still trying to enable the llvm_asm feature and fails to build. With this, it builds on my machine.