### PR TITLE
fix website address

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The program itself toggles a LED on PORTB periodically.
 
 Designed for the ATmega328p.
 
-[The AVR-Rust Book](https://book.avr-rust.com/)
+[The AVR-Rust Book](https://book.avr-rust.org/)
 
 ## Prerequisites
 
@@ -41,5 +41,5 @@ can be flashed directly to an AVR microcontroller or ran inside a simulator.
 
 ## Resources
 
-  * The [AVR-Rust book](https://book.avr-rust.com)
+  * The [AVR-Rust book](https://book.avr-rust.org)
 


### PR DESCRIPTION
Website address for The AVR-Rust Book in README.md is still set to https://book.avr-rust.com which no longer exists. Site is now hosted at https://book.avr-rust.org

When searching for AVR and Rust, this was the first page in my results. Submitting this pull request to help others find the correct resource.